### PR TITLE
데이터 생성 및 수정 날짜를 자동으로 관리

### DIFF
--- a/src/main/kotlin/com/sh/parkingmanagement/ParkingManagementKotlinApplication.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/ParkingManagementKotlinApplication.kt
@@ -2,10 +2,12 @@ package com.sh.parkingmanagement
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class ParkingManagementKotlinApplication
 
 fun main(args: Array<String>) {
-	runApplication<ParkingManagementKotlinApplication>(*args)
+    runApplication<ParkingManagementKotlinApplication>(*args)
 }

--- a/src/main/kotlin/com/sh/parkingmanagement/core/domain/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/core/domain/common/BaseTimeEntity.kt
@@ -1,0 +1,21 @@
+package com.sh.parkingmanagement.core.domain.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@EntityListeners(AuditingEntityListener::class)
+@MappedSuperclass
+abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    var createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null
+}


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요. -->
<!--
ex) close #1
-->
- close #15 
</br>
</br>

## 📂 작업 분류 <!-- 한개 이상 체크해주세요. -->
- [X] 기능 추가
- [ ] 기능 및 버그 수정
- [ ] 기능 업데이트
- [ ] 기능 삭제
- [ ] 문서 작업
- [ ] 설정 및 셋팅
- [ ] 기타
</br>
</br>

## 🔎 작업 내용(변경 사항) <!-- 자세히 작성해주세요. -->
<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->
- 데이터 생성, 수정 시 날짜를 자동으로 관리하기 위한 작업
- 데이터 생성 날짜, 수정 날짜를 관리하는 BaseTimeEntity 구현, 초기 null로 설정하고 JPA가 자동으로 날짜 정보를 업데이트
- 자동 타임스탬프 관리를 위해서 JPA Auditing 활성화
</br>
</br>

## 🚀 기타
- 
</br>
</br>
