### PR TITLE
OAuth2 설정 세팅 및 인증, 인가 구성

### DIFF
--- a/src/main/kotlin/com/sh/parkingmanagement/api/security/OAuth2LoginFailureCustomHandler.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/api/security/OAuth2LoginFailureCustomHandler.kt
@@ -1,0 +1,22 @@
+package com.sh.parkingmanagement.api.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.stereotype.Component
+
+/**
+ * OAuth2 로그인 실패 시 동작하는 핸들러
+ */
+@Component
+class OAuth2LoginFailureCustomHandler() : AuthenticationFailureHandler {
+
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        exception: AuthenticationException?
+    ) {
+        TODO("OAuth2 인증에 실패했을 경우, 예외처리")
+    }
+}

--- a/src/main/kotlin/com/sh/parkingmanagement/api/security/OAuth2LoginSuccessCustomHandler.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/api/security/OAuth2LoginSuccessCustomHandler.kt
@@ -1,0 +1,25 @@
+package com.sh.parkingmanagement.api.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+/**
+ * OAuth2 로그인 성공 시 동작하는 핸들러
+ * PrincipalDetailsService loadUser() 함수 호출 이후 실행
+ */
+@Component
+class OAuth2LoginSuccessCustomHandler(
+    private val jwtProvider: JwtProvider
+) : AuthenticationSuccessHandler {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        TODO("인증에 성공한 OAuth2 회원의 PrincipalDetails 정보를 기반으로 해당 회원이 서비스에 가입된 회원이면 JWT 응답하고 로그인 처리, 아닌 경우 OAuth2 정보를 응답하고 회원가입 필요 응답")
+    }
+}

--- a/src/main/kotlin/com/sh/parkingmanagement/api/security/PrincipalDetails.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/api/security/PrincipalDetails.kt
@@ -1,0 +1,27 @@
+package com.sh.parkingmanagement.api.security
+
+import com.sh.parkingmanagement.core.enums.UserRole
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+class PrincipalDetails(
+    val userId: Long?,
+    val socialProvider: String,
+    val socialId: String,
+    val role: UserRole?,
+    val attributes: Map<String, Any>
+) : OAuth2User {
+
+    override fun getName(): String = userId.toString()
+
+    override fun getAuthorities(): Collection<GrantedAuthority> {
+        return setOf(SimpleGrantedAuthority(role!!.name))
+    }
+
+    override fun getAttributes(): Map<String, Any> = attributes
+
+    fun getSocialProvider(): String = socialProvider
+
+    fun getSocialId(): String = socialId
+}

--- a/src/main/kotlin/com/sh/parkingmanagement/api/security/PrincipalDetailsService.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/api/security/PrincipalDetailsService.kt
@@ -1,0 +1,30 @@
+package com.sh.parkingmanagement.api.security
+
+import com.sh.parkingmanagement.core.domain.user.UserRepository
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+
+@Service
+class PrincipalDetailsService(
+    private val userRepository: UserRepository
+) : DefaultOAuth2UserService() {
+
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val oAuth2User: OAuth2User = super.loadUser(userRequest)
+
+        val registrationId = userRequest.clientRegistration.registrationId.uppercase()
+        val socialId = oAuth2User.attributes["id"].toString()
+
+        val user = userRepository.findUserEntityBySocialProviderAndSocialId(registrationId, socialId)
+
+        return PrincipalDetails(
+            userId = user?.id,
+            socialProvider = registrationId,
+            socialId = socialId,
+            role = user?.role,
+            attributes = oAuth2User.attributes
+        )
+    }
+}

--- a/src/main/kotlin/com/sh/parkingmanagement/core/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/sh/parkingmanagement/core/domain/user/UserRepository.kt
@@ -4,4 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<UserEntity, Long> {
 
+    fun findUserEntityBySocialProviderAndSocialId(
+        socialProvider: String,
+        socialId: String
+    ): UserEntity?
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,28 @@ spring:
       port: ${REDIS_PORT:6379}
       host: ${REDIS_HOST:localhost}
 
+  # security OAuth2
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            client-name: Kakao
+            provider: kakao
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-info-authentication-method: header
+            user-name-attribute: id
+
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요. -->
<!--
ex) close #1
-->
- close #17 
</br>
</br>

## 📂 작업 분류 <!-- 한개 이상 체크해주세요. -->
- [X] 기능 추가
- [ ] 기능 및 버그 수정
- [ ] 기능 업데이트
- [ ] 기능 삭제
- [ ] 문서 작업
- [ ] 설정 및 셋팅
- [ ] 기타
</br>
</br>

## 🔎 작업 내용(변경 사항) <!-- 자세히 작성해주세요. -->
<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->
- application.yml 파일에 OAuth2 관련 설정 세팅
`commit:` 761ca72d90e91dec40b5fb3a9134dffbc3bcdb6e
- OAuth2 사용자 정보(socialProvider, socialId)로 회원을 조회하는 findUserEntityBySocialProviderAndSocialId 로직 구현
`commit:` ab4e121ca19f5abf0437bd830d2e34e43a19d993
- 인증된 OAuth2 사용자 정보를 관리하는 OAuth2User 인터페이스 구현체 PrincipalDetails 클래스 구성
`commit:` c5098ff954e9d8ec4bafba230e9f96d0ae990e22
- 인증된 OAuth2 사용자 정보로 서비스 인증, 인가 로직을 담당하는 DefaultOAuth2UserService 인터페이스 구현체 PrincipalDetailsService 클래스 구성
`commit:` 8972bb906addb428adc837b6658b1642fd9d35ec
- OAuth2 인증 성공, 실패 시 동작하는 커스텀 핸들러 구성, 추후 상세 로직 구현 예정
`commit:` 13a7b93b88cef4e8d9a980a7527835985b34df95, a4060451ad253ac74e3ead1f55f1253e77bdb7d5
- SecurityConfig에 OAuth2 관련 설정 세팅
`commit:` 1d077266aba497a06a80ba6837269fe4789025fa
</br>
</br>

## 🚀 기타
- 
</br>
</br>
